### PR TITLE
Add `ag` (The Silver Searcher) to the eng build

### DIFF
--- a/Brewfile.eng
+++ b/Brewfile.eng
@@ -76,3 +76,7 @@ cask "font-anonymous-pro"
 
 #- Font [Cascadia](https://devblogs.microsoft.com/commandline/cascadia-code/) - This is a fun, new monospaced font that includes programming ligatures and is designed to enhance the modern look and feel of the Windows Terminal.
 cask "font-cascadia"
+
+#- [The Silver Searcher](https://github.com/ggreer/the_silver_searcher) - A code searching tool similar to ack (and grep), with a focus on speed.
+brew "the_silver_searcher"
+


### PR DESCRIPTION
Problem
-------

Neither `ack` nor `ag` are installed by default.  These tools both
provide `grep` like functionality but are tailored a bit for searching
through code.  `ag` was developed as an `ack` replacement and was built
for speed.

Solution
--------

Add `ag` as a default package to install with the rest of the eng stuff.

Readings
--------

https://github.com/ggreer/the_silver_searcher